### PR TITLE
merge payment-implementation-new into master

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# === PRZELEWY24 (SANDBOX) ===
+P24_BASE_URL=https://sandbox.przelewy24.pl/api/v1
+P24_REDIRECT_HOST=https://redirect.url.frontend
+P24_MERCHANT_ID=12345
+P24_POS_ID=12345
+P24_CRC_KEY=change_me
+P24_RETURN_URL=http://return.url.frontend
+P24_STATUS_URL=http://status.url
+P24_API_KEY=sample_key
+
+# === DATABASE ===
+DB_URL_LOCAL=jdbc:postgresql://name:port/database
+DB_URL_DOCKER=jdbc:postgresql://name:port/database
+DB_USERNAME=dbuser
+DB_PASSWORD=dbpassword
+
+# === SECURITY / KEYCLOAK ===
+KC_URL_LOCAL=http://localurl:port
+KC_URL_DOCKER=http://dockerurl:port
+KC_ISSUER_URI=realms/realmname
+KC_JWKS_URI=protocol/openid-connect/certs
+KC_ADMIN_LOGIN=login
+KC_ADMIN_PASS=pass

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.9'
 
 services:
   keycloak:
+    env_file: .env
     image: quay.io/keycloak/keycloak:26.0.1
     container_name: nesta-keycloak
     command:
@@ -12,23 +13,25 @@ services:
     volumes:
       - ./keycloak:/opt/keycloak/data/import
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: ${KC_ADMIN_LOGIN}
+      KEYCLOAK_ADMIN_PASSWORD: ${KC_ADMIN_PASS}
 
   postgres:
+    env_file: .env
     image: postgres:15
     container_name: nesta-db
     restart: unless-stopped
     environment:
       POSTGRES_DB: nesta
-      POSTGRES_USER: nesta_admin
-      POSTGRES_PASSWORD: letmein
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
       - "5433:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
 
   app:
+    env_file: .env
     build:
       context: .
       dockerfile: Dockerfile

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,15 @@
             <version>5.2.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+            <version>10.20.1</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/example/nesta/NestaApplication.java
+++ b/src/main/java/com/example/nesta/NestaApplication.java
@@ -2,8 +2,10 @@ package com.example.nesta;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class NestaApplication {
     public static void main(String[] args) {
         SpringApplication.run(NestaApplication.class, args);

--- a/src/main/java/com/example/nesta/config/JpaAuditingConfig.java
+++ b/src/main/java/com/example/nesta/config/JpaAuditingConfig.java
@@ -1,0 +1,11 @@
+package com.example.nesta.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+@Profile("!test")
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/example/nesta/config/SecurityConfig.java
+++ b/src/main/java/com/example/nesta/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET,  "/uploads/**").permitAll()
                         .requestMatchers(HttpMethod.HEAD, "/uploads/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "api/payments/webhook/p24").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2

--- a/src/main/java/com/example/nesta/controller/payment/PaymentController.java
+++ b/src/main/java/com/example/nesta/controller/payment/PaymentController.java
@@ -1,0 +1,51 @@
+package com.example.nesta.controller.payment;
+
+import com.example.nesta.payment.api.*;
+import com.example.nesta.service.payment.PaymentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/checkout")
+    public CheckoutResponse checkout(@Valid @RequestBody CheckoutRequest req,
+                                     @AuthenticationPrincipal Jwt jwt) {
+        String userId = jwt.getSubject();
+        return paymentService.createCheckout(req, userId);
+    }
+
+    // consider improvement?
+    @PostMapping("/webhook/p24")
+    public ResponseEntity<String> webhook(@RequestBody WebhookRequest req) throws IOException {
+        log.debug("======= WEBHOOK INITIALIZED =======");
+        log.debug(req.toString());
+        paymentService.handleP24Webhook(req);
+        return ResponseEntity.ok("OK");
+    }
+
+    @GetMapping("/{sessionId}")
+    public PaymentDto bySession(@PathVariable String sessionId,
+                                @AuthenticationPrincipal Jwt jwt) {
+        return paymentService.getBySession(sessionId, jwt.getSubject());
+    }
+
+    @GetMapping("/list")
+    public Page<PaymentListItemDto> listMine(@ModelAttribute PaymentQuery q, @AuthenticationPrincipal Jwt jwt) {
+        return paymentService.listMine(q, jwt.getSubject());
+    }
+}
+

--- a/src/main/java/com/example/nesta/controller/rentalinvoice/RentalInvoiceController.java
+++ b/src/main/java/com/example/nesta/controller/rentalinvoice/RentalInvoiceController.java
@@ -1,0 +1,50 @@
+package com.example.nesta.controller.rentalinvoice;
+
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceListItemDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceQuery;
+import com.example.nesta.service.rentalinvoice.RentalInvoiceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/invoices")
+@RequiredArgsConstructor
+public class RentalInvoiceController {
+    private final RentalInvoiceService rentalInvoiceService;
+
+    @PreAuthorize("hasRole(T(com.example.nesta.model.enums.UserRole).LANDLORD)")
+    @PostMapping("/create")
+    public RentalInvoiceDto create(@RequestBody RentalInvoiceDto req, @AuthenticationPrincipal Jwt jwt) {
+        return rentalInvoiceService.create(req, jwt.getSubject());
+    }
+
+    @PreAuthorize("hasRole(T(com.example.nesta.model.enums.UserRole).LANDLORD)")
+    @PutMapping("{id}")
+    public RentalInvoiceDto update(
+            @PathVariable UUID id,
+            @RequestBody RentalInvoiceDto dto,
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        return rentalInvoiceService.update(id, dto, jwt.getSubject());
+    }
+
+    @PreAuthorize("hasRole(T(com.example.nesta.model.enums.UserRole).LANDLORD)")
+    @DeleteMapping("{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable UUID id, @AuthenticationPrincipal Jwt jwt) {
+        rentalInvoiceService.delete(id, jwt.getSubject());
+    }
+
+    @GetMapping
+    public Page<RentalInvoiceListItemDto> listMine(@ModelAttribute RentalInvoiceQuery q, @AuthenticationPrincipal Jwt jwt) {
+        return rentalInvoiceService.listMine(q, jwt.getSubject());
+    }
+}

--- a/src/main/java/com/example/nesta/dto/rentalinvoice/RentalInvoiceDto.java
+++ b/src/main/java/com/example/nesta/dto/rentalinvoice/RentalInvoiceDto.java
@@ -1,0 +1,18 @@
+package com.example.nesta.dto.rentalinvoice;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record RentalInvoiceDto(
+        UUID id,
+        Long rentalOfferId,
+        String issuerId,
+        String receiverId,
+        Integer amountCents,
+        String currency,
+        Boolean paid,
+        String number,
+        Instant createdAt,
+        Instant updatedAt,
+        Instant paidAt
+) {}

--- a/src/main/java/com/example/nesta/dto/rentalinvoice/RentalInvoiceListItemDto.java
+++ b/src/main/java/com/example/nesta/dto/rentalinvoice/RentalInvoiceListItemDto.java
@@ -1,0 +1,16 @@
+package com.example.nesta.dto.rentalinvoice;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record RentalInvoiceListItemDto(
+        UUID id,
+        String number,
+        Integer amountCents,
+        String currency,
+        Boolean paid,
+        Instant createdAt,
+        Instant paidAt,
+        Long rentalOfferId
+) {
+}

--- a/src/main/java/com/example/nesta/dto/rentalinvoice/RentalInvoiceQuery.java
+++ b/src/main/java/com/example/nesta/dto/rentalinvoice/RentalInvoiceQuery.java
@@ -1,0 +1,20 @@
+package com.example.nesta.dto.rentalinvoice;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.Instant;
+
+public record RentalInvoiceQuery(
+        String number,
+        Boolean paid,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        Instant from,                               // createdAt >= from
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        Instant to,                                 // createdAt <= to
+        Long offerId,
+        Integer page,                               // default 0
+        Integer size,                               // default 20
+        String sortBy,                              // createdAt|paidAt|amountCents|number
+        String sortDir
+) {
+}

--- a/src/main/java/com/example/nesta/model/Payment.java
+++ b/src/main/java/com/example/nesta/model/Payment.java
@@ -1,31 +1,84 @@
 package com.example.nesta.model;
 
+import com.example.nesta.model.enums.PaymentStatus;
+import com.example.nesta.model.enums.VerificationStatus;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.util.UUID;
 
 @Entity
-@Data
+@Table(
+        name = "payment",
+        indexes = {
+                @Index(name = "idx_payment_session_id", columnList = "session_id", unique = true),
+                @Index(name = "idx_payment_user_created", columnList = "user_id, created_at"),
+                @Index(name = "idx_payment_invoice", columnList = "invoice_id")
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+@Getter @Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class Payment {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @UuidGenerator
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "invoice_id", nullable = false)
-    private RentalInvoice rentalInvoice;
+    @Column(name = "user_id", nullable = false, length = 64)
+    private String userId;
 
-    private BigDecimal amount;
+    @Column(name = "invoice_id")
+    private UUID invoiceId;
 
-    private LocalDateTime paymentDate;
+    @Column(name = "amount_cents", nullable = false)
+    private int amountCents;
 
-    private String method; // np. "PRZELEW", "KARTA", "P24"
+    @Column(name = "currency", nullable = false, length = 3)
+    private String currency = "PLN";
 
-    private String status; // np. "PENDING", "COMPLETED", "FAILED"
-} 
+    @Column(name = "method", nullable = false, length = 32)
+    private String method = "P24";
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private PaymentStatus status = PaymentStatus.PENDING;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "verification_status", nullable = false, length = 16)
+    private VerificationStatus verificationStatus = VerificationStatus.UNVERIFIED;
+
+    @Column(name = "session_id", nullable = false, unique = true, length = 128)
+    private String sessionId;
+
+    @Column(name = "p24_order_id")
+    private Long p24OrderId;
+
+    @Column(name = "p24_token", length = 256)
+    private String p24Token;
+
+    @Column(name = "paid_at")
+    private Instant paidAt;
+
+    @Lob
+    @Column(name = "raw_notification")
+    private String rawNotification;
+
+    /** Audit. */
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/src/main/java/com/example/nesta/model/RentalInvoice.java
+++ b/src/main/java/com/example/nesta/model/RentalInvoice.java
@@ -1,38 +1,66 @@
 package com.example.nesta.model;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
-
-import java.util.Date;
+import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.Instant;
 
 @Entity
-@Data
+@Table(name = "rental_invoice", indexes = {
+        @Index(name = "idx_invoice_user_created", columnList = "user_id, created_at"),
+        @Index(name = "idx_invoice_paid", columnList = "paid")
+})
+@EntityListeners(AuditingEntityListener.class)
+@Getter @Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
+@Builder
 public class RentalInvoice {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @ManyToOne
+    @Id
+    @UuidGenerator
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "rental_offer_id", nullable = false)
     private RentalOffer rentalOffer;
 
-    @Column(name = "rentier_id")
-    private String rentierId;
+    @Column(name = "issuer_user_id", nullable = false)
+    private String issuerId;     // landlord
 
-    @NotNull
-    private double amount;
+    @Column(name = "receiver_user_id")
+    private String receiverId;     // rentier
 
-    @NotNull
-    @Temporal(TemporalType.DATE)
-    private Date issueDate;
+    @Column(name = "number", length = 64)
+    private String number;
 
-    @NotNull
-    @Temporal(TemporalType.DATE)
-    private Date dueDate;
+    @Column(name = "amount_cents", nullable = false)
+    private int amountCents;
 
-    private boolean isPaid = false;
+    @Column(name = "currency", nullable = false, length = 3)
+    private String currency = "PLN";
+
+    @Column(name = "paid", nullable = false)
+    private boolean paid = false;
+
+    @Column(name = "paid_at")
+    private Instant paidAt;
+
+    @Column(name = "payment_id")
+    private UUID paymentId;
+
+    /** Audit. */
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
 }

--- a/src/main/java/com/example/nesta/model/enums/PaymentStatus.java
+++ b/src/main/java/com/example/nesta/model/enums/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.example.nesta.model.enums;
+
+public enum PaymentStatus {
+    PENDING,
+    PAID,
+    FAILED,
+    CANCELED
+}

--- a/src/main/java/com/example/nesta/model/enums/VerificationStatus.java
+++ b/src/main/java/com/example/nesta/model/enums/VerificationStatus.java
@@ -1,0 +1,6 @@
+package com.example.nesta.model.enums;
+
+public enum VerificationStatus {
+    UNVERIFIED,
+    VERIFIED
+}

--- a/src/main/java/com/example/nesta/payment/api/CheckoutRequest.java
+++ b/src/main/java/com/example/nesta/payment/api/CheckoutRequest.java
@@ -1,0 +1,10 @@
+package com.example.nesta.payment.api;
+
+import java.util.UUID;
+
+public record CheckoutRequest(
+        UUID invoiceId,
+        String email,
+        String description,
+        String returnUrl
+) {}

--- a/src/main/java/com/example/nesta/payment/api/CheckoutResponse.java
+++ b/src/main/java/com/example/nesta/payment/api/CheckoutResponse.java
@@ -1,0 +1,6 @@
+package com.example.nesta.payment.api;
+
+public record CheckoutResponse(
+        String sessionId,
+        String redirectUrl
+) {}

--- a/src/main/java/com/example/nesta/payment/api/PaymentDto.java
+++ b/src/main/java/com/example/nesta/payment/api/PaymentDto.java
@@ -1,0 +1,11 @@
+package com.example.nesta.payment.api;
+
+public record PaymentDto(
+        String sessionId,
+        String status,
+        int amountCents,
+        String currency,
+        String method,
+        String invoiceId,
+        String paidAt
+) {}

--- a/src/main/java/com/example/nesta/payment/api/PaymentListItemDto.java
+++ b/src/main/java/com/example/nesta/payment/api/PaymentListItemDto.java
@@ -1,0 +1,16 @@
+package com.example.nesta.payment.api;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record PaymentListItemDto(
+        UUID id,
+        String sessionId,
+        String status,
+        int amountCents,
+        String currency,
+        String method,
+        UUID invoiceId,
+        Instant createdAt,
+        Instant paidAt
+) {}

--- a/src/main/java/com/example/nesta/payment/api/PaymentQuery.java
+++ b/src/main/java/com/example/nesta/payment/api/PaymentQuery.java
@@ -1,0 +1,16 @@
+package com.example.nesta.payment.api;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record PaymentQuery(
+        String status,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        Instant from,                   // from createdAt
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        Instant to,                     // after createdAt
+        UUID invoiceId,
+        Integer page,                   // default 0
+        Integer size                    // default 20
+) {}

--- a/src/main/java/com/example/nesta/payment/api/RegisterPayload.java
+++ b/src/main/java/com/example/nesta/payment/api/RegisterPayload.java
@@ -1,0 +1,16 @@
+package com.example.nesta.payment.api;
+
+public record RegisterPayload(
+        int merchantId,
+        int posId,
+        String sessionId,
+        int amount,
+        String currency,
+        String description,
+        String email,
+        String country,
+        String language,
+        String urlReturn,
+        String urlStatus,
+        String sign
+) {}

--- a/src/main/java/com/example/nesta/payment/api/VerifyPayload.java
+++ b/src/main/java/com/example/nesta/payment/api/VerifyPayload.java
@@ -1,0 +1,11 @@
+package com.example.nesta.payment.api;
+
+public record VerifyPayload(
+        int merchantId,
+        int posId,
+        String sessionId,
+        int amount,
+        String currency,
+        long orderId,
+        String sign
+) {}

--- a/src/main/java/com/example/nesta/payment/api/WebhookRequest.java
+++ b/src/main/java/com/example/nesta/payment/api/WebhookRequest.java
@@ -1,0 +1,14 @@
+package com.example.nesta.payment.api;
+
+public record WebhookRequest(
+    int merchantId,
+    int posId,
+    String sessionId,
+    int amount,
+    int originAmount,
+    String currency,
+    long orderId,
+    Integer methodId,
+    String statement,
+    String sign
+){}

--- a/src/main/java/com/example/nesta/payment/p24/client/P24Client.java
+++ b/src/main/java/com/example/nesta/payment/p24/client/P24Client.java
@@ -1,0 +1,170 @@
+package com.example.nesta.payment.p24.client;
+
+import com.example.nesta.payment.api.RegisterPayload;
+import com.example.nesta.payment.api.VerifyPayload;
+import com.example.nesta.payment.p24.config.P24Properties;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+
+@Slf4j
+@Component
+public class P24Client {
+    private final RestTemplate restTemplate;
+    private final P24Properties props;
+
+    public P24Client(P24Properties props) {
+        this.props = props;
+        this.restTemplate = new RestTemplate();
+    }
+
+    public RegisterResponse register(RegisterRequest req) throws Exception {
+        String toSign = createSignJson(req.sessionId, "merchantId", req.merchantId, req.amount,req.currency, props.crcKey());
+        log.debug("=========STRING IDACY DO SHA=========");
+        log.debug(toSign);
+        String sign = sha384Hex(toSign);
+        log.debug(sign);
+        RegisterPayload payload = new RegisterPayload(
+                req.merchantId,
+                req.posId,
+                req.sessionId,
+                req.amount,
+                req.currency,
+                req.description,
+                req.email,
+                req.country,
+                req.language,
+                req.urlReturn,
+                req.urlStatus,
+                sign
+        );
+        log.debug("+++++++ REGISTER PAYLOAD +++++++");
+        log.debug(payload.toString());
+
+        HttpEntity<RegisterPayload> entity = new HttpEntity<>(payload, authHeaders());
+        log.debug("=== Sending register request to P24 ===");
+        RegisterEnvelopeResponse resp = restTemplate.postForObject(
+                props.baseUrl() + "/transaction/register",
+                entity,
+                RegisterEnvelopeResponse.class
+        );
+        if (resp != null) {
+            log.debug("REGISTER RESPONSE: data: " + resp.data);
+        }
+        if (resp == null || resp.data() == null || resp.data().token() == null) {
+            throw new IllegalStateException("P24 register failed: " + (resp == null ? "null" : resp.error()));
+        }
+        return resp.data();
+    }
+
+    public VerifyResponse verify(VerifyRequest req) throws Exception {
+        String toSign = createSignJson(req.sessionId, "orderId", req.orderId, req.amount,req.currency, props.crcKey());
+        String sign = sha384Hex(toSign);
+        VerifyPayload payload = new VerifyPayload(
+                req.merchantId,
+                req.posId,
+                req.sessionId,
+                req.amount,
+                req.currency,
+                req.orderId,
+                sign
+        );
+        log.debug("+++++++ VERIFY PAYLOAD +++++++");
+        log.debug(payload.toString());
+
+
+        HttpEntity<VerifyPayload> entity = new HttpEntity<>(payload, authHeaders());
+        log.debug("=== Sending verify request to P24 ===");
+        VerifyEnvelopeResponse resp = restTemplate.exchange(
+                props.baseUrl() + "/transaction/verify",
+                HttpMethod.PUT,
+                entity,
+                VerifyEnvelopeResponse.class
+        ).getBody();
+
+        if (resp == null || resp.data() == null) {
+            log.debug("VERIFY RESPONSE: data: " + resp.data);
+            throw new IllegalStateException("P24 verify failed: " + (resp == null ? "null" : resp.error()));
+        }
+        return resp.data();
+    }
+
+    private String sha384Hex(String data) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-384").digest(data.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("SHA-384 failed", e);
+        }
+    }
+
+    public record RegisterRequest(
+            int merchantId,
+            int posId,
+            String sessionId,
+            int amount,
+            String currency,
+            String description,
+            String email,
+            String country,
+            String language,
+            String urlReturn,
+            String urlStatus
+    ) {}
+
+    public record RegisterResponse(String token) {}
+    public record RegisterEnvelopeResponse(RegisterResponse data, String error) {}
+
+    public record VerifyRequest(
+            int merchantId,
+            int posId,
+            String sessionId,
+            int amount,
+            String currency,
+            long orderId
+    ) {}
+
+    public record VerifyResponse(String status) {}
+    public record VerifyEnvelopeResponse(VerifyResponse data, String error) {}
+
+    private HttpHeaders authHeaders() {
+        HttpHeaders h = new HttpHeaders();
+        h.setContentType(MediaType.APPLICATION_JSON);
+        h.setBasicAuth(String.valueOf(props.merchantId()), props.apiKey());
+        return h;
+    }
+
+    private static String createSignJson(String sessionId, String idKey, long idValue, int amount, String currency, String crc) throws Exception {
+        ObjectNode n = MAPPER.createObjectNode();
+        n.put("sessionId", sessionId);
+        n.put(idKey, idValue);
+        n.put("amount", amount);
+        n.put("currency", currency);
+        n.put("crc", crc);
+        return MAPPER.writeValueAsString(n);
+    }
+
+    // make sure deserialization doesn't mess up json request properties order, cause it will break sign
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .disable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .disable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);
+
+}
+
+
+

--- a/src/main/java/com/example/nesta/payment/p24/config/P24Properties.java
+++ b/src/main/java/com/example/nesta/payment/p24/config/P24Properties.java
@@ -1,0 +1,17 @@
+package com.example.nesta.payment.p24.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "nesta.p24")
+public record P24Properties(
+        String baseUrl,
+        String redirectHost,
+        int merchantId,
+        int posId,
+        String apiKey,
+        String crcKey,
+        String returnUrl,
+        String statusUrl
+) {}

--- a/src/main/java/com/example/nesta/repository/payment/PaymentRepository.java
+++ b/src/main/java/com/example/nesta/repository/payment/PaymentRepository.java
@@ -1,0 +1,15 @@
+package com.example.nesta.repository.payment;
+
+import java.util.UUID;
+
+import com.example.nesta.model.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PaymentRepository extends JpaRepository<Payment, UUID>, PaymentRepositoryQuery {
+
+    Payment findBySessionId(String sessionId);
+
+    @Query("select p from Payment p where p.invoiceId = :invoiceId and p.status = 'PENDING'")
+    Payment findPendingByInvoiceId(UUID invoiceId);
+}

--- a/src/main/java/com/example/nesta/repository/payment/PaymentRepositoryQuery.java
+++ b/src/main/java/com/example/nesta/repository/payment/PaymentRepositoryQuery.java
@@ -1,0 +1,9 @@
+package com.example.nesta.repository.payment;
+
+import com.example.nesta.payment.api.PaymentListItemDto;
+import com.example.nesta.payment.api.PaymentQuery;
+import org.springframework.data.domain.Page;
+
+public interface PaymentRepositoryQuery {
+    Page<PaymentListItemDto> searchMine(PaymentQuery q, String userId);
+}

--- a/src/main/java/com/example/nesta/repository/payment/impl/PaymentRepositoryImpl.java
+++ b/src/main/java/com/example/nesta/repository/payment/impl/PaymentRepositoryImpl.java
@@ -1,0 +1,84 @@
+package com.example.nesta.repository.payment.impl;
+
+
+import com.example.nesta.repository.payment.PaymentRepositoryQuery;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.example.nesta.payment.api.PaymentListItemDto;
+import com.example.nesta.payment.api.PaymentQuery;
+import java.util.Objects;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+import lombok.RequiredArgsConstructor;
+
+import static com.example.nesta.model.QPayment.payment;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements PaymentRepositoryQuery {
+
+    private final JPAQueryFactory qf;
+
+    @Override
+    public Page<PaymentListItemDto> searchMine(PaymentQuery q, String userId) {
+        int page = q.page() != null ? q.page() : 0;
+        int size = q.size() != null ? q.size() : 20;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        var where = new BooleanBuilder()
+                .and(payment.userId.eq(userId));
+
+        if (q.status() != null && !q.status().isBlank()) {
+            where.and(payment.status.stringValue().equalsIgnoreCase(q.status()));
+        }
+        if (q.from() != null) {
+            where.and(payment.createdAt.goe(q.from()));
+        }
+        if (q.to() != null) {
+            where.and(payment.createdAt.loe(q.to()));
+        }
+        if (q.invoiceId() != null) {
+            where.and(payment.invoiceId.eq(q.invoiceId()));
+        }
+
+        var baseQuery = qf.select(Projections.constructor(
+                        PaymentListItemDto.class,
+                        payment.id,
+                        payment.sessionId,
+                        payment.status.stringValue(),
+                        payment.amountCents,
+                        payment.currency,
+                        payment.method,
+                        payment.invoiceId,
+                        payment.createdAt,
+                        payment.paidAt
+                ))
+                .from(payment)
+                .where(where);
+
+        // default sort by createdAt
+        var sort = pageable.getSort().stream().findFirst().orElse(Sort.Order.desc("createdAt"));
+        var direction = sort.isAscending() ? com.querydsl.core.types.Order.ASC
+                : com.querydsl.core.types.Order.DESC;
+        var orderBy = switch (sort.getProperty()) {
+            case "paidAt"    -> new OrderSpecifier<>(direction, payment.paidAt);
+            case "amountCents" -> new OrderSpecifier<>(direction, payment.amountCents);
+            default          -> new OrderSpecifier<>(direction, payment.createdAt);
+        };
+
+        var content = baseQuery
+                .orderBy(orderBy)
+                .offset((long) pageable.getPageNumber() * pageable.getPageSize())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = qf.select(payment.count())
+                .from(payment)
+                .where(where)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, Objects.requireNonNullElse(total, 0L));
+    }
+}

--- a/src/main/java/com/example/nesta/repository/rentalinvoice/RentalInvoiceRepository.java
+++ b/src/main/java/com/example/nesta/repository/rentalinvoice/RentalInvoiceRepository.java
@@ -1,0 +1,18 @@
+package com.example.nesta.repository.rentalinvoice;
+
+import com.example.nesta.model.RentalInvoice;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RentalInvoiceRepository extends JpaRepository<RentalInvoice, UUID>, RentalInvoiceRepositoryQuery {
+    @Query("""
+        select i
+        from RentalInvoice i
+        where i.id = :id and (i.issuerId = :userId or i.receiverId = :userId)
+    """)
+    Optional<RentalInvoice> findByIdAndUserId(UUID id, String userId);
+}
+

--- a/src/main/java/com/example/nesta/repository/rentalinvoice/RentalInvoiceRepositoryQuery.java
+++ b/src/main/java/com/example/nesta/repository/rentalinvoice/RentalInvoiceRepositoryQuery.java
@@ -1,0 +1,9 @@
+package com.example.nesta.repository.rentalinvoice;
+
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceListItemDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceQuery;
+import org.springframework.data.domain.Page;
+
+public interface RentalInvoiceRepositoryQuery {
+    Page<RentalInvoiceListItemDto> searchMine(RentalInvoiceQuery q, String userId);
+}

--- a/src/main/java/com/example/nesta/repository/rentalinvoice/impl/RentalInvoiceRepositoryImpl.java
+++ b/src/main/java/com/example/nesta/repository/rentalinvoice/impl/RentalInvoiceRepositoryImpl.java
@@ -1,0 +1,85 @@
+package com.example.nesta.repository.rentalinvoice.impl;
+
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceListItemDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceQuery;
+import com.example.nesta.repository.rentalinvoice.RentalInvoiceRepositoryQuery;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.util.Objects;
+
+import static com.example.nesta.model.QRentalInvoice.rentalInvoice;
+
+@Repository
+@RequiredArgsConstructor
+public class RentalInvoiceRepositoryImpl implements RentalInvoiceRepositoryQuery {
+
+    private final JPAQueryFactory qf;
+
+    @Override
+    public Page<RentalInvoiceListItemDto> searchMine(RentalInvoiceQuery q, String userId) {
+        int page = q.page() != null ? q.page() : 0;
+        int size = q.size() != null ? q.size() : 20;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        var where = new BooleanBuilder()
+                .and(rentalInvoice.issuerId.eq(userId).or(rentalInvoice.receiverId.eq(userId)));
+
+        if (q.number() != null && !q.number().isBlank()) {
+            where.and(rentalInvoice.number.containsIgnoreCase(q.number()));
+        }
+        if (q.paid() != null) {
+            where.and(rentalInvoice.paid.eq(q.paid()));
+        }
+        if (q.from() != null) {
+            where.and(rentalInvoice.createdAt.goe(q.from()));
+        }
+        if (q.to() != null) {
+            where.and(rentalInvoice.createdAt.loe(q.to()));
+        }
+        if (q.offerId() != null) {
+            where.and(rentalInvoice.rentalOffer.id.eq(q.offerId()));
+        }
+
+        var sort = pageable.getSort().stream().findFirst().orElse(Sort.Order.desc("createdAt"));
+        var direction = sort.isAscending() ? com.querydsl.core.types.Order.ASC
+                : com.querydsl.core.types.Order.DESC;
+        var orderBy = switch (sort.getProperty()) {
+            case "createdAt"    -> new OrderSpecifier<>(direction, rentalInvoice.createdAt);
+            case "amountCents" -> new OrderSpecifier<>(direction, rentalInvoice.amountCents);
+            default          -> new OrderSpecifier<>(direction, rentalInvoice.paid);
+        };
+
+        var baseQuery = qf.select(Projections.constructor(
+                        RentalInvoiceListItemDto.class,
+                        rentalInvoice.id,
+                        rentalInvoice.number,
+                        rentalInvoice.amountCents,
+                        rentalInvoice.currency,
+                        rentalInvoice.paid,
+                        rentalInvoice.createdAt,
+                        rentalInvoice.paidAt,
+                        rentalInvoice.rentalOffer.id
+                ))
+                .from(rentalInvoice)
+                .where(where);
+
+        var content = baseQuery
+                .orderBy(orderBy)
+                .offset((long) pageable.getPageNumber() * pageable.getPageSize())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = qf.select(rentalInvoice.count())
+                .from(rentalInvoice)
+                .where(where)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, Objects.requireNonNullElse(total, 0L));
+    }
+}

--- a/src/main/java/com/example/nesta/service/payment/PaymentService.java
+++ b/src/main/java/com/example/nesta/service/payment/PaymentService.java
@@ -1,0 +1,11 @@
+package com.example.nesta.service.payment;
+
+import com.example.nesta.payment.api.*;
+import org.springframework.data.domain.Page;
+
+public interface PaymentService {
+    CheckoutResponse createCheckout(CheckoutRequest req, String userId);
+    void handleP24Webhook(WebhookRequest req);
+    PaymentDto getBySession(String sessionId, String requesterId);
+    Page<PaymentListItemDto> listMine(PaymentQuery q, String userId);
+}

--- a/src/main/java/com/example/nesta/service/payment/PaymentServiceImpl.java
+++ b/src/main/java/com/example/nesta/service/payment/PaymentServiceImpl.java
@@ -1,0 +1,197 @@
+package com.example.nesta.service.payment;
+
+import com.example.nesta.model.Payment;
+import com.example.nesta.model.RentalInvoice;
+import com.example.nesta.model.enums.PaymentStatus;
+import com.example.nesta.model.enums.VerificationStatus;
+import com.example.nesta.payment.api.*;
+import com.example.nesta.payment.p24.client.P24Client;
+import com.example.nesta.payment.p24.config.P24Properties;
+import com.example.nesta.repository.payment.PaymentRepository;
+import com.example.nesta.repository.rentalinvoice.RentalInvoiceRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentServiceImpl implements PaymentService {
+
+    private final PaymentRepository paymentRepo;
+    private final RentalInvoiceRepository invoiceRepo;
+    private final P24Client p24;
+    private final P24Properties props;
+
+    @Override
+    @Transactional
+    public CheckoutResponse createCheckout(CheckoutRequest req, String userId) {
+        var invoice = invoiceRepo.findById(req.invoiceId())
+                .orElseThrow(() -> new IllegalArgumentException("Invoice not found: " + req.invoiceId()));
+
+        int amountCents = calculateAmountCents(invoice);
+        String sessionId = "payment-" + invoice.getId();
+
+        // redirect if existing
+        var existing = paymentRepo.findPendingByInvoiceId(invoice.getId());
+        log.debug("==== Redirecting because payment already exists ====");
+        if (existing != null && existing.getP24Token() != null) {
+            String cachedRedirect = props.redirectHost() + "/trnRequest/" + existing.getP24Token();
+            return new CheckoutResponse(existing.getSessionId(), cachedRedirect);
+        }
+
+        var payment = new Payment();
+        payment.setUserId(userId);
+        payment.setInvoiceId(invoice.getId());
+        payment.setAmountCents(amountCents);
+        payment.setCurrency("PLN");
+        payment.setMethod("P24");
+        payment.setStatus(PaymentStatus.PENDING);
+        payment.setVerificationStatus(VerificationStatus.UNVERIFIED);
+        payment.setSessionId(sessionId);
+        paymentRepo.save(payment);
+
+        var registerReq = new P24Client.RegisterRequest(
+                props.merchantId(),
+                props.posId(),
+                sessionId,
+                amountCents,
+                "PLN",
+                req.description() != null ? req.description() : ("Opłata za fakturę " + invoice.getNumber()),
+                req.email(),
+                "PL",
+                "pl",
+                req.returnUrl() != null ? req.returnUrl() : props.returnUrl(),
+                props.statusUrl()
+        );
+
+        P24Client.RegisterResponse registerResp;
+        try {
+            log.info("P24 props sanity: merchantId={}, posId={}, crc_len={}",
+                    props.merchantId(), props.posId(),
+                    props.crcKey() == null ? "null" : props.crcKey().length());
+
+            if (props.merchantId() == 0 || props.posId() == 0 || props.crcKey() == null || props.crcKey().isBlank()) {
+                throw new IllegalStateException("P24 config missing: merchantId/posId/crc must be set");
+            }
+            registerResp = p24.register(registerReq);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        payment.setP24Token(registerResp.token());
+        paymentRepo.save(payment);
+
+        String redirectUrl = props.redirectHost() + "/trnRequest/" + registerResp.token();
+        return new CheckoutResponse(sessionId, redirectUrl);
+    }
+
+    @Override
+    @Transactional
+    public void handleP24Webhook(WebhookRequest req) {
+        log.debug("SERVICE INIT HANDLE WEEBHOOK");
+        log.debug("DATA IS: " + req.toString());
+
+        String sessionId = req.sessionId();
+        Integer amount = req.amount();
+        String currency = req.currency();
+
+        if (sessionId == null || amount == null || currency == null) return;
+
+        var payment = paymentRepo.findBySessionId(sessionId);
+        if (payment == null) return;
+
+        // if paid already return
+        if (payment.getStatus() == PaymentStatus.PAID) return;
+
+        // simple validation, if currency or amount wrong, save notification but don't confirm
+        if (payment.getAmountCents() != amount || !"PLN".equals(currency)) {
+            payment.setRawNotification("Currency/amount mismatch payment attempt :"
+                    + amount + "/" + currency);
+            paymentRepo.save(payment);
+            return;
+        }
+
+        // verify
+        var verifyReq = new P24Client.VerifyRequest(
+                req.merchantId(),
+                req.posId(),
+                sessionId,
+                amount,
+                currency,
+                req.orderId()
+        );
+
+        P24Client.VerifyResponse verify;
+        try {
+            log.debug("CALLING P24 CLIENT WITH VERIFY REQUEST");
+            verify = p24.verify(verifyReq);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        if (verify.status().equals("success")) {
+            payment.setStatus(PaymentStatus.PAID);
+            payment.setVerificationStatus(VerificationStatus.VERIFIED);
+            payment.setPaidAt(Instant.now());
+            payment.setRawNotification(truncate(req.toString(), 4000));
+            paymentRepo.save(payment);
+
+            invoiceRepo.findById(payment.getInvoiceId()).ifPresent(inv -> {
+                inv.setPaid(true);
+                inv.setPaidAt(payment.getPaidAt());
+                inv.setPaymentId(payment.getId());
+                invoiceRepo.save(inv);
+            });
+        } else {
+            // save notification if failed, TODO retry payment?
+            payment.setStatus(PaymentStatus.FAILED);
+            payment.setRawNotification(truncate(req.toString(), 4000));
+            paymentRepo.save(payment);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaymentDto getBySession(String sessionId, String requesterId) {
+        var p = paymentRepo.findBySessionId(sessionId);
+        if (p == null) throw new IllegalArgumentException("Payment not found");
+        if (!p.getUserId().equals(requesterId) && !isAdmin()) {
+            throw new SecurityException("Forbidden");
+        }
+        return new PaymentDto(
+                p.getSessionId(),
+                p.getStatus().name(),
+                p.getAmountCents(),
+                p.getCurrency(),
+                p.getMethod(),
+                p.getInvoiceId() != null ? p.getInvoiceId().toString() : null,
+                p.getPaidAt() != null ? p.getPaidAt().toString() : null
+        );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<PaymentListItemDto> listMine(PaymentQuery q, String userId) {
+        return paymentRepo.searchMine(q, userId);
+    }
+
+    private int calculateAmountCents(RentalInvoice inv) {
+        // TODO, currency?
+        return inv.getAmountCents();
+    }
+
+    private String truncate(String s, int max) {
+        return (s == null || s.length() <= max) ? s : s.substring(0, max);
+    }
+
+    // TODO: get this somehow from keycloak?
+    private boolean isAdmin() {
+        return false;
+    }
+}

--- a/src/main/java/com/example/nesta/service/rentalinvoice/RentalInvoiceService.java
+++ b/src/main/java/com/example/nesta/service/rentalinvoice/RentalInvoiceService.java
@@ -1,0 +1,15 @@
+package com.example.nesta.service.rentalinvoice;
+
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceListItemDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceQuery;
+import org.springframework.data.domain.Page;
+
+import java.util.UUID;
+
+public interface RentalInvoiceService {
+    RentalInvoiceDto create(RentalInvoiceDto req, String jwt);
+    Page<RentalInvoiceListItemDto> listMine(RentalInvoiceQuery q, String userId);
+    RentalInvoiceDto update(UUID id, RentalInvoiceDto update, String userId);
+    void delete(UUID id, String userId);
+}

--- a/src/main/java/com/example/nesta/service/rentalinvoice/RentalInvoiceServiceImpl.java
+++ b/src/main/java/com/example/nesta/service/rentalinvoice/RentalInvoiceServiceImpl.java
@@ -1,0 +1,125 @@
+package com.example.nesta.service.rentalinvoice;
+
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceListItemDto;
+import com.example.nesta.dto.rentalinvoice.RentalInvoiceQuery;
+import com.example.nesta.model.RentalInvoice;
+import com.example.nesta.model.RentalOffer;
+import com.example.nesta.repository.rentalinvoice.RentalInvoiceRepository;
+import com.example.nesta.repository.rentaloffer.RentalOfferRepository;
+import com.example.nesta.utils.InvoiceNumberGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RentalInvoiceServiceImpl implements RentalInvoiceService {
+
+    private final RentalInvoiceRepository invoiceRepo;
+    private final RentalOfferRepository rentalOfferRepo;
+    private final InvoiceNumberGenerator numberGenerator;
+
+    @Override
+    @Transactional
+    public RentalInvoiceDto create(RentalInvoiceDto req, String userId) {
+        RentalOffer offer = rentalOfferRepo.findById(req.rentalOfferId())
+                .orElseThrow(() -> new IllegalArgumentException("Offer with id %s does not exist".formatted(req.rentalOfferId())));
+
+        RentalInvoice inv = new RentalInvoice();
+        inv.setRentalOffer(offer);
+        inv.setIssuerId(userId);
+        inv.setReceiverId(req.receiverId()); // if rentalOffer will hold the rentier info, change it to load from there
+        inv.setAmountCents(req.amountCents());
+        inv.setCurrency(req.currency() != null ? req.currency() : "PLN");
+        inv.setPaid(false);
+
+        int attempts = 0;
+        while (true) {
+            attempts++;
+            inv.setNumber(numberGenerator.generate(Instant.now(), userId));
+            try {
+                RentalInvoice saved = invoiceRepo.save(inv);
+                return toDto(saved);
+            } catch (DataIntegrityViolationException e) {
+                if (attempts >= 5) throw e;
+            }
+        }
+    }
+
+    @Override
+    public RentalInvoiceDto update(UUID id, RentalInvoiceDto invoiceDto, String userId) {
+        var inv = invoiceRepo.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new NoSuchElementException("Invoice not found"));
+        log.debug("Service: found candidate for update, DTO is: ");
+        log.debug(invoiceDto.toString());
+        if (invoiceDto.amountCents() != null) {
+            if (invoiceDto.amountCents() <= 0) throw new IllegalArgumentException("amountCents must be > 0");
+            log.debug("Recognized amount from DTO, updating");
+            inv.setAmountCents(invoiceDto.amountCents());
+        }
+
+        if (invoiceDto.currency() != null && !invoiceDto.currency().isBlank()) {
+            inv.setCurrency(invoiceDto.currency().trim().toUpperCase());
+        }
+
+        if (invoiceDto.paid() != null) {
+            boolean newPaid = invoiceDto.paid();
+            inv.setPaid(newPaid);
+
+            if (newPaid) {
+                inv.setPaidAt(invoiceDto.paidAt() != null ? invoiceDto.paidAt() : Instant.now());
+            } else {
+                inv.setPaidAt(null);
+            }
+        } else if (invoiceDto.paidAt() != null) {
+            if (inv.isPaid()) {
+                inv.setPaidAt(invoiceDto.paidAt());
+            } else {
+                throw new IllegalArgumentException("Cannot set paidAt when paid=false");
+            }
+        }
+        invoiceRepo.save(inv);
+        return toDto(inv);
+    }
+
+    @Override
+    public void delete(UUID id, String userId) {
+        var inv = invoiceRepo.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new NoSuchElementException("Invoice not found"));
+
+        if (inv.isPaid()) {
+            throw new IllegalStateException("Paid invoices cannot be deleted");
+        }
+        invoiceRepo.delete(inv);
+    }
+
+    @Override
+    public Page<RentalInvoiceListItemDto> listMine(RentalInvoiceQuery q, String userId) {
+        return invoiceRepo.searchMine(q, userId);
+    }
+
+    private static RentalInvoiceDto toDto(RentalInvoice e) {
+        return new RentalInvoiceDto(
+                e.getId(),
+                e.getRentalOffer() != null ? e.getRentalOffer().getId() : null,
+                e.getIssuerId(),
+                e.getReceiverId(),
+                e.getAmountCents(),
+                e.getCurrency(),
+                e.isPaid(),
+                e.getNumber(),
+                e.getCreatedAt(),
+                e.getUpdatedAt(),
+                e.getPaidAt()
+        );
+    }
+}

--- a/src/main/java/com/example/nesta/utils/InvoiceNumberGenerator.java
+++ b/src/main/java/com/example/nesta/utils/InvoiceNumberGenerator.java
@@ -1,0 +1,37 @@
+package com.example.nesta.utils;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+@Component
+public class InvoiceNumberGenerator {
+
+    private static final DateTimeFormatter DATE =
+            DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC);
+
+    private static final String ALPHA = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private final SecureRandom random = new SecureRandom();
+
+    public String generate(Instant createdAtUtc, String userId) {
+        String date = DATE.format(createdAtUtc);
+
+        String userPrefix = (userId != null && userId.length() >= 4)
+                ? userId.substring(0, 4).toUpperCase()
+                : (userId != null ? userId.toUpperCase() : "USID");
+
+        String rand = randomString(6);
+        return "INV-" + date + "-" + userPrefix + "-" + rand;
+    }
+
+    private String randomString(int len) {
+        StringBuilder sb = new StringBuilder(len);
+        for (int i = 0; i < len; i++) {
+            sb.append(ALPHA.charAt(random.nextInt(ALPHA.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,9 +1,9 @@
 # PostgreSQL
-spring.datasource.url=jdbc:postgresql://postgres:5432/nesta
-spring.datasource.username=nesta_admin
-spring.datasource.password=letmein
+spring.datasource.url=${DB_URL_DOCKER}
+spring.datasource.username=${DB_USERNAME:postgres}
+spring.datasource.password=${DB_PASSWORD:postgres}
 
 # Keycloak
-keycloak.base-url=http://keycloak:8080
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://keycloak:8080/realms/nesta-realm
-keycloak.token-url=http://keycloak:8080/realms/nesta-realm/protocol/openid-connect/token
+keycloak.base-url=${KC_URL_DOCKER}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KC_URL_DOCKER}/${KC_ISSUER_URI}
+keycloak.token-url=${KC_URL_DOCKER}/${KC_ISSUER_URI}/${KC_JWKS_URI}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,9 +1,9 @@
 # PostgreSQL
-spring.datasource.url=jdbc:postgresql://localhost:5433/nesta
-spring.datasource.username=nesta_admin
-spring.datasource.password=letmein
+spring.datasource.url=${DB_URL_LOCAL}
+spring.datasource.username=${DB_USERNAME:postgres}
+spring.datasource.password=${DB_PASSWORD:postgres}
 
 # Keycloak
-keycloak.base-url=http://localhost:8080
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/realms/nesta-realm
-keycloak.token-url=http://localhost:8080/realms/nesta-realm/protocol/openid-connect/token
+keycloak.base-url=${KC_URL_LOCAL}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KC_URL_LOCAL}/${KC_ISSUER_URI}
+keycloak.token-url=${KC_URL_LOCAL}/${KC_ISSUER_URI}/${KC_JWKS_URI}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,2 @@
+spring.flyway.enabled=false
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,27 @@
 spring.application.name=Nesta
 
 # JPA / Hibernate
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.driver-class-name=org.postgresql.Driver
+
+# Flyway
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+spring.flyway.baseline-version=0
+spring.flyway.schemas=public
+spring.flyway.default-schema=public
+spring.flyway.table=flyway_schema_history
+
+# P24 properties
+nesta.p24.base-url=${P24_BASE_URL}
+nesta.p24.crc-key=${P24_CRC_KEY}
+nesta.p24.merchant-id=${P24_MERCHANT_ID}
+nesta.p24.pos-id=${P24_POS_ID}
+nesta.p24.redirect-host=${P24_REDIRECT_HOST}
+nesta.p24.return-url=${P24_RETURN_URL}
+nesta.p24.status-url=${P24_STATUS_URL}
+nesta.p24.api-key=${P24_API_KEY}
 
 # Logging
 logging.level.root=DEBUG

--- a/src/main/resources/db/migration/V01_20250823__rental_invoice_audit_defaults.sql
+++ b/src/main/resources/db/migration/V01_20250823__rental_invoice_audit_defaults.sql
@@ -1,0 +1,6 @@
+ALTER TABLE rental_invoice
+    ALTER COLUMN created_at SET DEFAULT NOW(),
+    ALTER COLUMN updated_at SET DEFAULT NOW();
+
+UPDATE rental_invoice SET created_at = NOW() WHERE created_at IS NULL;
+UPDATE rental_invoice SET updated_at = NOW() WHERE updated_at IS NULL;

--- a/src/main/resources/db/migration/V02_20250823__create_move_in_application.sql
+++ b/src/main/resources/db/migration/V02_20250823__create_move_in_application.sql
@@ -1,0 +1,29 @@
+-- Create table
+CREATE TABLE IF NOT EXISTS move_in_application (
+    id                      BIGSERIAL PRIMARY KEY,
+    rental_offer_id         BIGINT NOT NULL,
+    rentier_id              VARCHAR(255),
+    viewing_datetime        TIMESTAMPTZ NOT NULL,
+    landlord_status         VARCHAR(50) NOT NULL DEFAULT 'PENDING',
+    rentier_status          VARCHAR(50) NOT NULL DEFAULT 'PENDING',
+    landlord_decision_reason VARCHAR(300),
+    rentier_decision_reason  VARCHAR(300),
+    created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    landlord_decided_at     TIMESTAMPTZ,
+    rentier_decided_at      TIMESTAMPTZ
+);
+
+-- Foreign key to rental_offer(id)
+ALTER TABLE move_in_application
+    ADD CONSTRAINT fk_move_in_application_rental_offer
+        FOREIGN KEY (rental_offer_id) REFERENCES rental_offer(id);
+
+-- Helpful indexes
+CREATE INDEX IF NOT EXISTS idx_move_in_application_rental_offer_id
+    ON move_in_application (rental_offer_id);
+
+CREATE INDEX IF NOT EXISTS idx_move_in_application_rentier_id
+    ON move_in_application (rentier_id);
+
+CREATE INDEX IF NOT EXISTS idx_move_in_application_created_at
+    ON move_in_application (created_at);

--- a/src/main/resources/db/migration/V03_20250824__invoice_remove_offer_constraint_add_number_constraints_indexes.sql
+++ b/src/main/resources/db/migration/V03_20250824__invoice_remove_offer_constraint_add_number_constraints_indexes.sql
@@ -1,0 +1,34 @@
+ALTER TABLE rental_invoice
+    ALTER COLUMN number TYPE varchar(40);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_rental_invoice_number
+    ON rental_invoice (number)
+    WHERE number IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ix_rental_invoice_user_created
+    ON rental_invoice (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS ix_rental_invoice_paid
+    ON rental_invoice (paid);
+
+DO $$
+    DECLARE
+        cons_name text;
+    BEGIN
+        SELECT c.conname INTO cons_name
+        FROM pg_constraint c
+                 JOIN pg_class t ON t.oid = c.conrelid
+        WHERE t.relname = 'rental_invoice'
+          AND c.contype = 'u'
+          AND cardinality(c.conkey) = 1
+          AND (
+                  SELECT att.attname
+                  FROM pg_attribute att
+                  WHERE att.attrelid = t.oid
+                    AND att.attnum = c.conkey[1]
+              ) = 'rental_offer_id';
+
+        IF cons_name IS NOT NULL THEN
+            EXECUTE format('ALTER TABLE rental_invoice DROP CONSTRAINT %I', cons_name);
+        END IF;
+    END $$;

--- a/src/main/resources/db/migration/V04_20250824__invoice_split_user_id_into_issuer_receiver.sql
+++ b/src/main/resources/db/migration/V04_20250824__invoice_split_user_id_into_issuer_receiver.sql
@@ -1,0 +1,9 @@
+ALTER TABLE rental_invoice RENAME COLUMN user_id TO issuer_user_id;
+
+ALTER TABLE rental_invoice ADD COLUMN receiver_user_id text;
+
+CREATE INDEX IF NOT EXISTS idx_rental_invoice_issuer ON rental_invoice(issuer_user_id);
+CREATE INDEX IF NOT EXISTS idx_rental_invoice_receiver ON rental_invoice(receiver_user_id);
+
+ALTER TABLE rental_invoice
+    ALTER COLUMN issuer_user_id SET NOT NULL;

--- a/src/main/resources/db/migration/V05_20250825__create_apartment_image.sql
+++ b/src/main/resources/db/migration/V05_20250825__create_apartment_image.sql
@@ -1,0 +1,17 @@
+CREATE TABLE apartment_image (
+                                 id BIGSERIAL PRIMARY KEY,
+                                 apartment_id BIGINT NOT NULL,
+                                 relative_path VARCHAR(512) NOT NULL,
+                                 public_url VARCHAR(512) NOT NULL,
+                                 content_type VARCHAR(128),
+                                 size_bytes BIGINT,
+                                 width INT,
+                                 height INT,
+                                 CONSTRAINT fk_apartment_image_apartment
+                                     FOREIGN KEY (apartment_id)
+                                         REFERENCES apartment (id)
+                                         ON DELETE CASCADE
+);
+
+CREATE INDEX idx_apartment_image_apartment_id
+    ON apartment_image(apartment_id);

--- a/src/test/java/com/example/nesta/repository/apartment/ApartmentRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/nesta/repository/apartment/ApartmentRepositoryIntegrationTest.java
@@ -12,10 +12,12 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class ApartmentRepositoryIntegrationTest {
     @Autowired
     private ApartmentRepository apartmentRepository;

--- a/src/test/java/com/example/nesta/repository/rentaloffer/RentalOfferRepositoryIntegrationTest.java
+++ b/src/test/java/com/example/nesta/repository/rentaloffer/RentalOfferRepositoryIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -27,6 +28,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class RentalOfferRepositoryIntegrationTest {
     @Autowired
     private RentalOfferRepository rentalOfferRepository;


### PR DESCRIPTION
- introduced secrets
- added .env.example: template to fill in local .env file
- introduced flyway outside tests
- enabled configurationpropertiesscan on main app class
- introduced jpa auditing outside tests
- allowed permitAll on webhook in security config for p24 to easily post
- added payment controller with minimum endpoints
- added rental invoice controller with minimum endpoints
- added multiple query and requests dtos
- payment and rental invoice entities refactor
- added P24 client to handle communication with third party payment system provider
- added payment and rental invoice repositories, following queryDSL pattern
- added payment and rental services implementations, functionality over code quality for now, consider later improvements/refactors
- invoice number generator for custom invoices number (considers issuer id for now, should be receiver eventually)
- added test profile
- annotaded existing integration tests with test profile